### PR TITLE
Fix weather forecast day handling

### DIFF
--- a/app/services/weather.py
+++ b/app/services/weather.py
@@ -74,14 +74,13 @@ def get_weather_forecast(city: str, days: int = 3) -> str:
             desc = entry["weather"][0]["description"]
 
             if date_str != current_day:
+                if count >= days:
+                    break
                 count += 1
                 current_day = date_str
                 output += f"\n📅 {date_str}:\n"
 
             output += f"  - {time_str} → {temp:.1f}°C, {desc}\n"
-
-            if count >= days:
-                break
         # print("**********************************************************")
         # print(output)
         # print("**********************************************************")


### PR DESCRIPTION
## Summary
- fix the forecast loop in `weather.py` so the last day isn't truncated

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685eeb7dd0f08322a437ede4e7056d5d